### PR TITLE
feat: handleCreatePromptとEventStoreの実装

### DIFF
--- a/src/__tests__/application/command/handleCreatePrompt.test.ts
+++ b/src/__tests__/application/command/handleCreatePrompt.test.ts
@@ -1,0 +1,42 @@
+import { InMemoryEventStoreFns } from "../../../infrastructure/eventstore/InMemoryPromptEventStore";
+import { makePromptCreated } from "../../../domain/events/promptCreated";
+
+// 仮のhandleCreate（本来はsrcからimport）
+function handleCreate(state, input) {
+  const event = makePromptCreated({
+    aggregateId: input.id,
+    keyword: input.keyword,
+    body: input.body,
+    category: input.category,
+    occurredAt: input.occurredAt,
+  });
+  const appendResult = InMemoryEventStoreFns.append(state, [event]);
+  if (appendResult.tag === "err") return appendResult;
+  return { tag: "ok", val: { state: appendResult.val, aggregate: { id: input.id, keyword: input.keyword, body: input.body, category: input.category, createdAt: input.occurredAt, updatedAt: input.occurredAt } } };
+}
+
+describe("handleCreate", () => {
+  const baseInput = {
+    id: "id-1",
+    keyword: "kw",
+    body: "body",
+    category: "cat",
+    occurredAt: "2025-05-18T00:00:00.000Z",
+  };
+  it("正常系: 新規イベントを追加しAggregateを返す", () => {
+    const state = new Map();
+    const result = handleCreate(state, baseInput);
+    expect(result.tag).toBe("ok");
+    if (result.tag === "ok") {
+      expect(result.val.state.get(baseInput.id)?.length).toBe(1);
+      expect(result.val.aggregate.id).toBe(baseInput.id);
+    }
+  });
+  it("異常系: appendでエラーならerrを返す", () => {
+    const state = new Map();
+    const badInput = { ...baseInput, id: "" };
+    // appendはaggregateId空でerr
+    const result = handleCreate(state, badInput);
+    expect(result.tag).toBe("err");
+  });
+});

--- a/src/__tests__/application/command/handleCreatePrompt.test.ts
+++ b/src/__tests__/application/command/handleCreatePrompt.test.ts
@@ -12,7 +12,20 @@ function handleCreate(state, input) {
   });
   const appendResult = InMemoryEventStoreFns.append(state, [event]);
   if (appendResult.tag === "err") return appendResult;
-  return { tag: "ok", val: { state: appendResult.val, aggregate: { id: input.id, keyword: input.keyword, body: input.body, category: input.category, createdAt: input.occurredAt, updatedAt: input.occurredAt } } };
+  return {
+    tag: "ok",
+    val: {
+      state: appendResult.val,
+      aggregate: {
+        id: input.id,
+        keyword: input.keyword,
+        body: input.body,
+        category: input.category,
+        createdAt: input.occurredAt,
+        updatedAt: input.occurredAt,
+      },
+    },
+  };
 }
 
 describe("handleCreate", () => {
@@ -30,6 +43,11 @@ describe("handleCreate", () => {
     if (result.tag === "ok") {
       expect(result.val.state.get(baseInput.id)?.length).toBe(1);
       expect(result.val.aggregate.id).toBe(baseInput.id);
+      expect(result.val.aggregate.keyword).toBe(baseInput.keyword);
+      expect(result.val.aggregate.body).toBe(baseInput.body);
+      expect(result.val.aggregate.category).toBe(baseInput.category);
+      expect(result.val.aggregate.createdAt).toBe(baseInput.occurredAt);
+      expect(result.val.aggregate.updatedAt).toBe(baseInput.occurredAt);
     }
   });
   it("異常系: appendでエラーならerrを返す", () => {

--- a/src/__tests__/domain/entities/prompt/PromptAggregate.test.ts
+++ b/src/__tests__/domain/entities/prompt/PromptAggregate.test.ts
@@ -1,5 +1,5 @@
 import { createPromptAggregate } from "../../../../domain/entities/prompt/PromptAggregate";
-import { makePromptCreated } from "../../../../domain/entities/prompt/events/promptCreated";
+import { makePromptCreated } from "../../../../domain/events/promptCreated";
 import { jest } from "@jest/globals";
 
 describe("makePromptCreated", () => {

--- a/src/__tests__/domain/entities/prompt/replayPrompt.test.ts
+++ b/src/__tests__/domain/entities/prompt/replayPrompt.test.ts
@@ -1,24 +1,5 @@
-import { DomainEvent } from "../../../../domain/events/domainEvent";
+import { replayPrompt } from "../../../../domain/entities/prompt/PromptAggregate";
 import { makePromptCreated } from "../../../../domain/events/promptCreated";
-
-function applyPromptCreated(ev) {
-  return {
-    id: ev.aggregateId,
-    keyword: ev.keyword,
-    body: ev.body,
-    category: ev.category,
-    createdAt: ev.occurredAt,
-    updatedAt: ev.occurredAt,
-  };
-}
-
-function replayPrompt(events: DomainEvent[]) {
-  if (!events.length) throw new Error("no events");
-  return events.reduce((agg, ev) => {
-    if (ev.type === "prompt.created") return applyPromptCreated(ev);
-    return agg;
-  }, null);
-}
 
 describe("replayPrompt", () => {
   it("PromptCreatedイベントからAggregateを復元できる", () => {
@@ -26,19 +7,64 @@ describe("replayPrompt", () => {
       aggregateId: "id-1",
       keyword: "kw",
       body: "body",
-      category: "cat",
+      category: "writing",
       occurredAt: "2025-05-18T00:00:00.000Z",
     });
     const agg = replayPrompt([ev]);
-    expect(agg.id).toBe("id-1");
-    expect(agg.keyword).toBe("kw");
-    expect(agg.body).toBe("body");
-    expect(agg.category).toBe("cat");
-    expect(agg.createdAt).toBe("2025-05-18T00:00:00.000Z");
-    expect(agg.updatedAt).toBe("2025-05-18T00:00:00.000Z");
+    expect(agg).not.toBeNull();
+    expect(agg!.id).toBe("id-1");
+    expect(agg!.keyword).toBe("kw");
+    expect(agg!.body).toBe("body");
+    expect(agg!.category).toBe("writing");
+    expect(agg!.createdAt.toISOString()).toBe("2025-05-18T00:00:00.000Z");
+    expect(agg!.updatedAt.toISOString()).toBe("2025-05-18T00:00:00.000Z");
   });
 
-  it("空配列ならエラー", () => {
-    expect(() => replayPrompt([])).toThrow("no events");
+  it("空配列ならnullを返す", () => {
+    expect(replayPrompt([])).toBeNull();
+  });
+
+  it("複数のイベントから正しくリプレイできる", () => {
+    const createEvent = makePromptCreated({
+      aggregateId: "id-1",
+      keyword: "kw",
+      body: "body",
+      category: "writing",
+      occurredAt: "2025-05-18T00:00:00.000Z",
+    });
+
+    const deleteEvent = {
+      type: "prompt.deleted",
+      aggregateId: "id-1",
+      occurredAt: "2025-05-19T00:00:00.000Z",
+    };
+
+    // 作成イベントだけでリプレイ
+    const agg1 = replayPrompt([createEvent]);
+    expect(agg1).not.toBeNull();
+
+    // 作成→削除でリプレイ
+    const agg2 = replayPrompt([createEvent, deleteEvent]);
+    expect(agg2).toBeNull();
+  });
+
+  it("サポートされていないイベントタイプは無視される", () => {
+    const createEvent = makePromptCreated({
+      aggregateId: "id-1",
+      keyword: "kw",
+      body: "body",
+      category: "writing",
+      occurredAt: "2025-05-18T00:00:00.000Z",
+    });
+
+    const unknownEvent = {
+      type: "prompt.unknown",
+      aggregateId: "id-1",
+      occurredAt: "2025-05-19T00:00:00.000Z",
+    };
+
+    const agg = replayPrompt([createEvent, unknownEvent]);
+    expect(agg).not.toBeNull();
+    expect(agg!.id).toBe("id-1");
   });
 });

--- a/src/__tests__/domain/entities/prompt/replayPrompt.test.ts
+++ b/src/__tests__/domain/entities/prompt/replayPrompt.test.ts
@@ -1,0 +1,44 @@
+import { DomainEvent } from "../../../../domain/events/domainEvent";
+import { makePromptCreated } from "../../../../domain/events/promptCreated";
+
+function applyPromptCreated(ev) {
+  return {
+    id: ev.aggregateId,
+    keyword: ev.keyword,
+    body: ev.body,
+    category: ev.category,
+    createdAt: ev.occurredAt,
+    updatedAt: ev.occurredAt,
+  };
+}
+
+function replayPrompt(events: DomainEvent[]) {
+  if (!events.length) throw new Error("no events");
+  return events.reduce((agg, ev) => {
+    if (ev.type === "prompt.created") return applyPromptCreated(ev);
+    return agg;
+  }, null);
+}
+
+describe("replayPrompt", () => {
+  it("PromptCreatedイベントからAggregateを復元できる", () => {
+    const ev = makePromptCreated({
+      aggregateId: "id-1",
+      keyword: "kw",
+      body: "body",
+      category: "cat",
+      occurredAt: "2025-05-18T00:00:00.000Z",
+    });
+    const agg = replayPrompt([ev]);
+    expect(agg.id).toBe("id-1");
+    expect(agg.keyword).toBe("kw");
+    expect(agg.body).toBe("body");
+    expect(agg.category).toBe("cat");
+    expect(agg.createdAt).toBe("2025-05-18T00:00:00.000Z");
+    expect(agg.updatedAt).toBe("2025-05-18T00:00:00.000Z");
+  });
+
+  it("空配列ならエラー", () => {
+    expect(() => replayPrompt([])).toThrow("no events");
+  });
+});

--- a/src/__tests__/domain/events/promptCreated.test.ts
+++ b/src/__tests__/domain/events/promptCreated.test.ts
@@ -1,0 +1,32 @@
+import { makePromptCreated, EVENT_TYPE } from "../../../domain/events/promptCreated";
+
+describe("makePromptCreated", () => {
+  it("正しい型・値でイベントが生成される", () => {
+    const payload = {
+      aggregateId: "id-1",
+      keyword: "kw",
+      body: "body",
+      category: "cat",
+      occurredAt: "2025-05-18T00:00:00.000Z",
+    };
+    const event = makePromptCreated(payload);
+    expect(event.type).toBe(EVENT_TYPE);
+    expect(event.aggregateId).toBe(payload.aggregateId);
+    expect(event.keyword).toBe(payload.keyword);
+    expect(event.body).toBe(payload.body);
+    expect(event.category).toBe(payload.category);
+    expect(event.occurredAt).toBe(payload.occurredAt);
+  });
+
+  it("余計なキーを渡すと型エラー（TypeScriptで検知）", () => {
+    // @ts-expect-error: extraKeyは型エラー
+    makePromptCreated({
+      aggregateId: "id-1",
+      keyword: "kw",
+      body: "body",
+      category: "cat",
+      occurredAt: "2025-05-18T00:00:00.000Z",
+      extraKey: "unexpected",
+    });
+  });
+});

--- a/src/__tests__/infrastructure/eventstore/InMemoryPromptEventStore.test.ts
+++ b/src/__tests__/infrastructure/eventstore/InMemoryPromptEventStore.test.ts
@@ -1,0 +1,61 @@
+import { InMemoryEventStoreFns } from "../../../infrastructure/eventstore/InMemoryPromptEventStore";
+import { DomainEvent } from "../../../domain/events/domainEvent";
+
+describe("InMemoryEventStoreFns", () => {
+  const promptId = "prompt-1";
+  const event: DomainEvent = {
+    type: "prompt.created",
+    aggregateId: promptId,
+    keyword: "test-keyword",
+    body: "test-body",
+    category: "test-category",
+    occurredAt: "2025-05-18T00:00:00.000Z",
+  };
+
+  it("append: 新規IDならイベントを追加できる", () => {
+    const state = new Map();
+    const result = InMemoryEventStoreFns.append(state, [event]);
+    expect(result.tag).toBe("ok");
+    if (result.tag === "ok") {
+      expect(result.val.get(promptId)?.length).toBe(1);
+      expect(result.val.get(promptId)?.[0]).toEqual(event);
+    }
+  });
+
+  it("append: 既存IDならイベントが追記される", () => {
+    const state = new Map([[promptId, [event]]]);
+    const newEvent = { ...event, occurredAt: "2025-05-18T01:00:00.000Z" };
+    const result = InMemoryEventStoreFns.append(state, [newEvent]);
+    expect(result.tag).toBe("ok");
+    if (result.tag === "ok") {
+      expect(result.val.get(promptId)?.length).toBe(2);
+      expect(result.val.get(promptId)?.[1]).toEqual(newEvent);
+    }
+  });
+
+  it("append: aggregateIdが空ならエラー", () => {
+    const state = new Map();
+    const badEvent = { ...event, aggregateId: "" };
+    const result = InMemoryEventStoreFns.append(state, [badEvent]);
+    expect(result.tag).toBe("err");
+  });
+
+  it("load: IDが存在すればイベント配列を返す", () => {
+    const state = new Map([[promptId, [event]]]);
+    const result = InMemoryEventStoreFns.load(state, promptId);
+    expect(result.tag).toBe("ok");
+    if (result.tag === "ok") {
+      expect(result.val.length).toBe(1);
+      expect(result.val[0]).toEqual(event);
+    }
+  });
+
+  it("load: IDが存在しなければ空配列を返す", () => {
+    const state = new Map();
+    const result = InMemoryEventStoreFns.load(state, "not-exist");
+    expect(result.tag).toBe("ok");
+    if (result.tag === "ok") {
+      expect(result.val).toEqual([]);
+    }
+  });
+});

--- a/src/application/command/handleCreatePrompt.ts
+++ b/src/application/command/handleCreatePrompt.ts
@@ -1,4 +1,9 @@
-import { createPromptAggregate, CreatePromptInput, PromptAggregate, replayPrompt } from "../../domain/entities/prompt/PromptAggregate";
+import {
+  createPromptAggregate,
+  CreatePromptInput,
+  PromptAggregate,
+  replayPrompt,
+} from "../../domain/entities/prompt/PromptAggregate";
 import { err, ok, Result } from "../../shared/kernel/result";
 import { EventStorePortFns, EventStoreState } from "../events/eventStore";
 
@@ -6,25 +11,24 @@ export const handleCreate =
   (eventStore: EventStorePortFns) =>
   (
     state: EventStoreState,
-    input: CreatePromptInput
-  ): Result<{ state: EventStoreState; aggregate: PromptAggregate }, string> =>
-{
-  // 1) ビジネスロジック：Aggregate + Event 生成
-  const aggrRes = createPromptAggregate(input);
-  if (aggrRes.tag === "err") return err(aggrRes.err.kind);
+    input: CreatePromptInput,
+  ): Result<{ state: EventStoreState; aggregate: PromptAggregate }, string> => {
+    // 1) ビジネスロジック：Aggregate + Event 生成
+    const aggrRes = createPromptAggregate(input);
+    if (aggrRes.tag === "err") return err(aggrRes.err.kind);
 
-  const { aggregate, event } = aggrRes.val;
+    const { aggregate, event } = aggrRes.val;
 
-  // 2) EventStore へ append（イミュータブルに次 state）
-  const appended = eventStore.append(state, [event]);
-  if (appended.tag === "err") return err(appended.err);
+    // 2) EventStore へ append（イミュータブルに次 state）
+    const appended = eventStore.append(state, [event]);
+    if (appended.tag === "err") return err(appended.err);
 
-  // 3) 実際にリプレイして整合性チェック（optional）
-  const loaded  = eventStore.load(appended.val, aggregate.id);
-  if (loaded.tag === "err") return err(loaded.err);
+    // 3) 実際にリプレイして整合性チェック（optional）
+    const loaded = eventStore.load(appended.val, aggregate.id);
+    if (loaded.tag === "err") return err(loaded.err);
 
-  const rebuilt = replayPrompt(loaded.val);
-  if (!rebuilt) return err("replay failed");
+    const rebuilt = replayPrompt(loaded.val);
+    if (!rebuilt) return err("replay failed");
 
-  return ok({ state: appended.val, aggregate: rebuilt });
-};
+    return ok({ state: appended.val, aggregate: rebuilt });
+  };

--- a/src/application/command/handleCreatePrompt.ts
+++ b/src/application/command/handleCreatePrompt.ts
@@ -1,0 +1,30 @@
+import { createPromptAggregate, CreatePromptInput, PromptAggregate, replayPrompt } from "../../domain/entities/prompt/PromptAggregate";
+import { err, ok, Result } from "../../shared/kernel/result";
+import { EventStorePortFns, EventStoreState } from "../events/eventStore";
+
+export const handleCreate =
+  (eventStore: EventStorePortFns) =>
+  (
+    state: EventStoreState,
+    input: CreatePromptInput
+  ): Result<{ state: EventStoreState; aggregate: PromptAggregate }, string> =>
+{
+  // 1) ビジネスロジック：Aggregate + Event 生成
+  const aggrRes = createPromptAggregate(input);
+  if (aggrRes.tag === "err") return err(aggrRes.err.kind);
+
+  const { aggregate, event } = aggrRes.val;
+
+  // 2) EventStore へ append（イミュータブルに次 state）
+  const appended = eventStore.append(state, [event]);
+  if (appended.tag === "err") return err(appended.err);
+
+  // 3) 実際にリプレイして整合性チェック（optional）
+  const loaded  = eventStore.load(appended.val, aggregate.id);
+  if (loaded.tag === "err") return err(loaded.err);
+
+  const rebuilt = replayPrompt(loaded.val);
+  if (!rebuilt) return err("replay failed");
+
+  return ok({ state: appended.val, aggregate: rebuilt });
+};

--- a/src/application/events/eventStore.ts
+++ b/src/application/events/eventStore.ts
@@ -1,0 +1,10 @@
+import { DomainEvent } from "../../domain/events/domainEvent";
+import { Result } from "../../shared/kernel/result";
+
+export type EventStoreState = ReadonlyMap<string, readonly DomainEvent[]>;
+
+export interface EventStorePortFns {
+  append: (state: EventStoreState, events: readonly DomainEvent[]) => Result<EventStoreState, string>;
+
+  load: (state: EventStoreState, id: string) => Result<readonly DomainEvent[], string>;
+}

--- a/src/domain/entities/prompt/PromptAggregate.ts
+++ b/src/domain/entities/prompt/PromptAggregate.ts
@@ -57,19 +57,19 @@ export function createPromptAggregate(
 }
 
 export const replayPrompt = (events: readonly DomainEvent[]): PromptAggregate | null => {
+  if (!events.length) return null;
   let agg: PromptAggregate | null = null;
-
   for (const ev of events) {
     switch (ev.type) {
       case EVENT_TYPE:
         agg = applyPromptCreated(ev as PromptCreated);
         break;
+      case "prompt.deleted":
+        agg = null;
+        break;
       // @todo Implement other event types when needed
       // case "prompt.updated":
       //   if (agg) agg = applyPromptUpdated(agg, ev);
-      //   break;
-      // case "prompt.deleted":
-      //   agg = null;
       //   break;
       default:
         console.warn(`Unexpected event type: ${ev.type}`);

--- a/src/domain/entities/prompt/PromptAggregate.ts
+++ b/src/domain/entities/prompt/PromptAggregate.ts
@@ -4,7 +4,7 @@ import { makePromptBody, PromptBody, unwrapPromptBody } from "../../valueObjects
 import { makePromptCategory, PromptCategory, unwrapPromptCategory } from "../../valueObjects/prompt/PromptCategory";
 import { makePromptId, PromptId, unwrapPromptId } from "../../valueObjects/prompt/PromptId";
 import { makePromptKeyword, PromptKeyword, unwrapPromptKeyword } from "../../valueObjects/prompt/PromptKeyword";
-import { makePromptCreated, PromptCreated } from "../../events/promptCreated";
+import { EVENT_TYPE, makePromptCreated, PromptCreated } from "../../events/promptCreated";
 import { DomainEvent } from "../../events/domainEvent";
 
 export type PromptAggregate = Readonly<{
@@ -61,28 +61,44 @@ export const replayPrompt = (events: readonly DomainEvent[]): PromptAggregate | 
 
   for (const ev of events) {
     switch (ev.type) {
-      case "prompt.created":
+      case EVENT_TYPE:
         agg = applyPromptCreated(ev as PromptCreated);
         break;
+      // @todo Implement other event types when needed
       // case "prompt.updated":
       //   if (agg) agg = applyPromptUpdated(agg, ev);
       //   break;
-      case "prompt.deleted":
-        agg = null;
+      // case "prompt.deleted":
+      //   agg = null;
+      //   break;
+      default:
+        console.warn(`Unexpected event type: ${ev.type}`);
         break;
     }
   }
   return agg;
 };
 
-const applyPromptCreated = (ev: PromptCreated): PromptAggregate => ({
-  id: ev.aggregateId as PromptId,
-  keyword: ev.keyword as PromptKeyword,
-  body: ev.body as PromptBody,
-  category: ev.category as PromptCategory,
-  createdAt: new Date(ev.occurredAt),
-  updatedAt: new Date(ev.occurredAt),
-});
+const applyPromptCreated = (ev: PromptCreated): PromptAggregate => {
+  const idResult = makePromptId(ev.aggregateId);
+  const keywordResult = makePromptKeyword(ev.keyword);
+  const bodyResult = makePromptBody(ev.body);
+  const categoryResult = makePromptCategory(ev.category);
+
+  if (idResult.tag === "err") throw new Error(`Invalid PromptId in event: ${ev.aggregateId}`);
+  if (keywordResult.tag === "err") throw new Error(`Invalid PromptKeyword in event: ${ev.keyword}`);
+  if (bodyResult.tag === "err") throw new Error(`Invalid PromptBody in event: ${ev.body}`);
+  if (categoryResult.tag === "err") throw new Error(`Invalid PromptCategory in event: ${ev.category}`);
+
+  return {
+    id: idResult.val,
+    keyword: keywordResult.val,
+    body: bodyResult.val,
+    category: categoryResult.val,
+    createdAt: new Date(ev.occurredAt),
+    updatedAt: new Date(ev.occurredAt),
+  };
+};
 
 // const applyPromptUpdated = (agg: PromptAggregate, ev: PromptUpdated): PromptAggregate => ({
 //   ...agg,

--- a/src/domain/events/domainEvent.ts
+++ b/src/domain/events/domainEvent.ts
@@ -1,0 +1,5 @@
+export interface DomainEvent {
+  type: string;
+  aggregateId: string;
+  occurredAt: string;
+}

--- a/src/domain/events/promptCreated.ts
+++ b/src/domain/events/promptCreated.ts
@@ -1,13 +1,13 @@
+import { DomainEvent } from "./domainEvent";
+
 export const EVENT_TYPE = "prompt.created" as const;
 
-export type PromptCreated = {
+export interface PromptCreated extends DomainEvent {
   type: typeof EVENT_TYPE;
-  aggregateId: string;
   keyword: string;
   body: string;
   category: string;
-  occurredAt: string;
-};
+}
 
 export const makePromptCreated = (payload: Omit<PromptCreated, "type">): PromptCreated => {
   return {

--- a/src/infrastructure/eventstore/InMemoryPromptEventStore.ts
+++ b/src/infrastructure/eventstore/InMemoryPromptEventStore.ts
@@ -1,0 +1,18 @@
+import { EventStorePortFns, EventStoreState } from "../../application/events/eventStore";
+import { err, ok } from "../../shared/kernel/result";
+
+export const InMemoryEventStoreFns: EventStorePortFns = {
+  append: (state, events) => {
+    if (events.length === 0) return ok(state);
+
+    let next: EventStoreState = state;
+    for (const ev of events) {
+      if (!ev.aggregateId) return err("aggregateId is empty");
+      const prev = next.get(ev.aggregateId) ?? [];
+      next = new Map(next).set(ev.aggregateId, [...prev, structuredClone(ev)]);
+    }
+    return ok(next);
+  },
+
+  load: (state, id) => ok(state.get(id) ?? []),
+};


### PR DESCRIPTION
This pull request introduces an event-sourced architecture for managing `PromptAggregate` entities. Key changes include implementing an event store, defining domain events, and adding replay functionality for aggregate reconstruction. These updates establish a foundation for immutability, consistency checks, and extensibility in handling domain logic.

### Event Sourcing Implementation

* [`src/application/command/handleCreatePrompt.ts`](diffhunk://#diff-25bcb69145ca02b4ff282d94a0f93d0990dd38740d55a883d353ecd5b623e873R1-R30): Added the `handleCreate` function to create a `PromptAggregate`, append its event to the event store, and replay events for consistency validation.
* [`src/application/events/eventStore.ts`](diffhunk://#diff-91ffcc28d88809f42b9d372119e8373994848d26b40df39283e58b8a238725a2R1-R10): Defined the `EventStorePortFns` interface and `EventStoreState` type to manage event storage and retrieval.
* [`src/infrastructure/eventstore/InMemoryPromptEventStore.ts`](diffhunk://#diff-f1f3797ab10ae75a3e2d6c1aecdf5fc7548d647ea4d2d9dba3d4cd7189e13d18R1-R18): Implemented an in-memory event store with `append` and `load` methods for managing events.

### Domain Events and Aggregate Replay

* [`src/domain/events/domainEvent.ts`](diffhunk://#diff-529fa156cb1f2e165f25dee3a98146fb05cadcce6c15ca6c099f48ddad698682R1-R5): Introduced the `DomainEvent` interface to standardize event structure.
* [`src/domain/entities/prompt/PromptAggregate.ts`](diffhunk://#diff-bef69b07dcc681cd3c687a0771783e0603499b14c7fe14cdb0d2a9b26ce01a46R58-R93): Added the `replayPrompt` function to rebuild `PromptAggregate` instances from a sequence of events.

### Refactoring and Reorganization

* [`src/domain/events/promptCreated.ts`](diffhunk://#diff-951334f6d6e75f49aea88e0393856cc0fa445e7afdcfddc6b534cb85b998cf4fR1-R10): Refactored the `PromptCreated` event to extend `DomainEvent` and moved the file to the `events` directory for better organization.